### PR TITLE
Update browserOutput.dm

### DIFF
--- a/code/modules/goonchat/browserOutput.dm
+++ b/code/modules/goonchat/browserOutput.dm
@@ -207,11 +207,19 @@ var/emojiJson = file2text("code/modules/goonchat/browserassets/js/emojiList.json
 	if (!obj)
 		return
 
-	if (isicon(obj))
+	// This check will check for an icon object that already has a cool key.
+	if (istype(obj, /icon))
 		var/icon/I = obj
 		if(!bicon_cache[I.icon_info])
 			bicon_cache[I.icon_info] = icon2base64(obj)
 		return "[bicon_cache[I.icon_info]]"
+
+	// This check will check if you pass it to this proc 'foo/bar.dmi', or something from your computer in game
+	if(isicon(obj))
+		var/key = "\ref[obj]"
+		if(!bicon_cache[key])
+			bicon_cache[key] = icon2base64(obj)
+		return "[bicon_cache[key]]"
 
 	if (!isatom(obj)) // we don't need datums here. no runtimes :<
 		return

--- a/code/modules/goonchat/browserOutput.dm
+++ b/code/modules/goonchat/browserOutput.dm
@@ -179,7 +179,11 @@ var/emojiJson = file2text("code/modules/goonchat/browserassets/js/emojiList.json
 
 /icon/New(icon,icon_state,dir,frame,moving)
 	..()
-	icon_info = "[icon]#[icon_state]"
+	// A link to ourselves, otherwise a file. A kind of guarantee.
+	if(istype(icon, /icon))
+		icon_info = "\ref[src]#[icon_state]"
+	else
+		icon_info = "\ref[icon]#[icon_state]"
 
 //Converts an icon to base64. Operates by putting the icon in the iconCache savefile,
 // exporting it as text, and then parsing the base64 from that.
@@ -205,7 +209,7 @@ var/emojiJson = file2text("code/modules/goonchat/browserassets/js/emojiList.json
 
 	if (isicon(obj))
 		var/icon/I = obj
-		if (!bicon_cache[I.icon_info]) // Doesn't exist yet, make it.
+		if(!bicon_cache[I.icon_info])
 			bicon_cache[I.icon_info] = icon2base64(obj)
 		return "[bicon_cache[I.icon_info]]"
 
@@ -213,11 +217,11 @@ var/emojiJson = file2text("code/modules/goonchat/browserassets/js/emojiList.json
 		return
 
 	var/atom/A = obj
-	var/key = "[istype(A.icon, /icon) ? "\ref[A.icon]" : A.icon]:[A.icon_state]"
+	var/key = "\ref[A.icon]#[A.icon_state]"
 	if (!bicon_cache[key]) // Doesn't exist, make it.
 		var/icon/I
-		if(!A.icon || !A.icon_state || !(A.icon_state in icon_states(A.icon))) // fixes freeze when client uses examine or anything else, when there is something wrong with icon data.
-			I = icon('icons/misc/buildmode.dmi', "buildhelp")                  // there is no logic with this icon choice, i just like it.
+		if(!A.icon_state || !(A.icon_state in icon_states(A.icon))) // fixes freeze when client uses examine or anything else, when there is something wrong with icon data.
+			I = A.icon ? A.icon : icon('icons/misc/buildmode.dmi', "buildhelp")                  // there is no logic with this icon choice, i just like it.
 		else
 			I = icon(A.icon, A.icon_state, SOUTH, 1)
 		if (ishuman(obj)) // Shitty workaround for a BYOND issue.

--- a/code/modules/goonchat/browserOutput.dm
+++ b/code/modules/goonchat/browserOutput.dm
@@ -179,7 +179,7 @@ var/emojiJson = file2text("code/modules/goonchat/browserassets/js/emojiList.json
 
 /icon/New(icon,icon_state,dir,frame,moving)
 	..()
-	// A link to ourselves, otherwise a file. A kind of guarantee.
+	// A link to yourself, otherwise a file. A kind of guarantee.
 	if(istype(icon, /icon))
 		icon_info = "\ref[src]#[icon_state]"
 	else

--- a/code/modules/goonchat/browserOutput.dm
+++ b/code/modules/goonchat/browserOutput.dm
@@ -174,6 +174,13 @@ var/emojiJson = file2text("code/modules/goonchat/browserassets/js/emojiList.json
 
 /var/list/bicon_cache = list()
 
+/icon
+	var/icon_info
+
+/icon/New(icon,icon_state,dir,frame,moving)
+	..()
+	icon_info = "[icon]#[icon_state]"
+
 //Converts an icon to base64. Operates by putting the icon in the iconCache savefile,
 // exporting it as text, and then parsing the base64 from that.
 // (This relies on byond automatically storing icons in savefiles as base64)
@@ -183,7 +190,8 @@ var/emojiJson = file2text("code/modules/goonchat/browserassets/js/emojiList.json
 	iconCache[iconKey] << icon
 	var/iconData = iconCache.ExportText(iconKey)
 	var/list/partial = splittext(iconData, "{")
-	return replacetext(copytext(partial[2], 3, -5), "\n", "")
+	var/list/almost_partial = splittext(partial[2], "}")
+	return replacetext(copytext(almost_partial[1], 3, -5), "\n", "")
 
 /proc/bicon(obj, css = "class='icon'") // if you don't want any styling just pass null to css
 	if (!obj)
@@ -196,9 +204,10 @@ var/emojiJson = file2text("code/modules/goonchat/browserassets/js/emojiList.json
 		return
 
 	if (isicon(obj))
-		if (!bicon_cache["\ref[obj]"]) // Doesn't exist yet, make it.
-			bicon_cache["\ref[obj]"] = icon2base64(obj)
-		return "[bicon_cache["\ref[obj]"]]"
+		var/icon/I = obj
+		if (!bicon_cache[I.icon_info]) // Doesn't exist yet, make it.
+			bicon_cache[I.icon_info] = icon2base64(obj)
+		return "[bicon_cache[I.icon_info]]"
 
 	if (!isatom(obj)) // we don't need datums here. no runtimes :<
 		return


### PR DESCRIPTION
Короче емае. Айконы странно работают. Но я смог кешировать динамические иконки. 

Вот типо доказательство

![image](https://user-images.githubusercontent.com/26389417/127931355-c9e20d4b-a03f-4b2c-b327-c5414f919a58.png)

![image](https://user-images.githubusercontent.com/26389417/127931367-967bf014-12dc-4170-8884-59d188ca1879.png)

Так же, позволяет кешировать вот такие вот картинки с компьютера. Я незнаю зачем но вот.
![image](https://user-images.githubusercontent.com/26389417/127932840-c26e4c6a-29e4-4751-9773-f91e4347c5e9.png)

Первый элемент: кэш мми, если экзамайнуть.
Второй элемент: кэш всех спрайтов в файле с мми. (это юзается при изменение через ВВ ийкона. Это не я придумал, но я это пофиксил)
Третий элемент: Осмотр мми, где вместо айкона - путин
Четвертный: аналогия с вторым элементом, но вместо файла с мми тут путин.
Пятый: Аналогично четвертому. Я уже не экзамайнил мми, где вместо айкона мем с негром на жёлтом фоне, но я потом в итоге это менял обратно на путина и поэтому он тут сохранился в кешэ.
![image](https://user-images.githubusercontent.com/26389417/127933618-37fbd78b-3f68-44f5-bffd-53eab5c9568f.png)

```
if (istype(obj, /icon))
Это проверяет именно на то, что `obj` является объектом типа `/icon`.

if(isicon(obj))
Это проверка на то, что obj уже хранится в кэше игры. Ну или как говорят доки: "This returns a true value when given an icon. Both /icon memory objects and icon files stored in the resource cache qualify."
Это значит, что 'foo/bar.dmi' уже в этом самом кэше. Загрузив с компа фотку putin.png, то 'putin.png' тоже будет являться айконом, ведь ты решил его загрузить в комп.
```
